### PR TITLE
fix: comparion of Timestamp with datetime.date

### DIFF
--- a/src/tryangle/model_selection/split.py
+++ b/src/tryangle/model_selection/split.py
@@ -28,7 +28,7 @@ class TriangleSplit(TimeSeriesSplit):
             [
                 date
                 for date in X.triangle.valuation.drop_duplicates().sort_values()
-                if date.date() <= valuation_date
+                if date.date() <= valuation_date.date()
             ]
         )
         for train, test in super().split(valuation_dates):


### PR DESCRIPTION
This small change should get rid of the following warning:

> tryangle/model_selection/split.py:31: FutureWarning: Comparison of Timestamp with datetime.date is deprecated in order to match the standard library behavior. In a future version these will be considered non-comparable. Use 'ts == pd.Timestamp(date)' or 'ts.date() == date' instead.

I received this warning when working with monthly data, so it is possible I made an error when defining my tryangle.